### PR TITLE
Store data in a different way, compatible with transcluded parent directives

### DIFF
--- a/demos/transclude.html
+++ b/demos/transclude.html
@@ -7,7 +7,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="viewport" content="width = device-width, minimal-ui, initial-scale = 1, user-scalable = no" />
     <meta name="apple-mobile-web-app-title" content="Datagrid">
-    <title>Datagrid - Expressive</title>
+    <title>Datagrid - Sorting</title>
     <base href="/">
     <style>
       *, *:after, *:before {
@@ -42,24 +42,16 @@
   </head>
   <body ng-app="app" ng-controller="HomeController">
 
-
-    <dtable options="options" rows="data" class="material dt">
-      <column name="Name" width="300" flex-grow="1"></column>
-      <column name="Gender" flex-grow="1">
-        {{monkey}} {{value}}
-      </column>
-    </dtable>
-
-    <dtable options="options2" rows="data" class="material dt">
-      <column name="Name" width="300"></column>
-      <column name="Company" width="300">
-        <div ng-repeat="v in vs">
-        {{v}} : {{row.name}} : {{value}}
-        </div>
-      </column>
-    </dtable>
-
-    <button type="button" ng-click="changeIt()">Change External Value</input>
+    <main-wrap>
+      <dtable options="options" rows="data" class="material">
+        <column name="Name" width="300">
+          <span>{{value}}</span>
+        </column>
+        <column name="Gender" width="700">
+          <span>{{value}} (mainwrapCtrl.bar: {{ mainwrapCtrl.bar }}) {{ foo }}</span>
+        </column>
+      </dtable>
+    </main-wrap>
 
     <script src="../jspm_packages/system.js"></script>
     <script src="../config.js"></script>
@@ -69,34 +61,34 @@
       System.import('dataTable').then(function(dt){
         var module = angular.module('app', [ dt.default.name ]);
 
+        module.controller('MainwrapCtrl', function($scope){
+          $scope.bar = 'valBar';
+        });
+
+
+        module.directive('mainWrap', function () {
+          return {
+            template: '<div>Outer template content. <br />Transcluded content:<div ng-transclude></div></div>',
+            restrict: 'EA',
+            transclude: true,
+            controller: 'MainwrapCtrl',
+            controllerAs: 'mainwrapCtrl'
+          };
+        });
+
+
         module.controller('HomeController', function($scope, $http){
-        $scope.vs = [ 1 ]
-
-        $scope.changeIt = function(){
-          $scope.vs[0] = 2;
-        }
-
           $scope.options = {
             rowHeight: 50,
-            footerHeight: false,
-            headerHeight: 50,
-            columnMode: 'flex',
-            scrollbarV: false,
-            selectable: false
-          };
-
-          $scope.options2 = {
-            rowHeight: 50,
             headerHeight: 50,
             footerHeight: false,
-            scrollbarV: false,
-            selectable: false
+            scrollbarV: false
           };
 
-          $scope.monkey = "iz";
+          $scope.foo = 'valFoo';
 
           $http.get('/demos/data/100.json').success(function(data) {
-            $scope.data = data.splice(0, 5);
+            $scope.data = data.splice(0, 15);
           });
 
         });

--- a/demos/transclude.html
+++ b/demos/transclude.html
@@ -42,18 +42,20 @@
   </head>
   <body ng-app="app" ng-controller="HomeController">
 
-    <main-wrap>
-      <dtable options="options" rows="data" class="material">
-        <column name="Name" width="300">
-          <span>{{value}}</span>
-        </column>
-        <column name="Gender" width="400">
-          <span>{{value}} <br>mainwrapCtrl.bar: <em>{{ mainwrapCtrl.bar }}</em> <br>$scope.foo: <em>{{ foo }}</em> <br>
-          <button ng-click="mainwrapCtrl.setBar('New Bar!')">Set "New Bar"</button>
-          </span>
-        </column>
-      </dtable>
-    </main-wrap>
+    <outer-wrap>
+      <inner-wrap>
+        <dtable options="options" rows="data" class="material">
+          <column name="Name" width="300">
+            <span>{{value}}</span>
+          </column>
+          <column name="Gender" width="400">
+            <span>{{value}} <br>mainwrapCtrl.bar: <em>{{ mainwrapCtrl.bar }}</em> <br>$scope.foo: <em>{{ foo }}</em> <br>
+            <button ng-click="mainwrapCtrl.setBar('New Bar!')">Set "New Bar"</button>
+            </span>
+          </column>
+        </dtable>
+      </inner-wrap>
+    </outer-wrap>
 
     <script src="../jspm_packages/system.js"></script>
     <script src="../config.js"></script>
@@ -63,21 +65,42 @@
       System.import('dataTable').then(function(dt){
         var module = angular.module('app', [ dt.default.name ]);
 
-        module.controller('MainwrapCtrl', function(){
+        module.controller('OuterwrapCtrl', function(){
           this.bar = 'valBar';
           this.setBar = function (val) {
             this.bar = val;
           };
         });
 
+        module.controller('InnerwrapCtrl', function(){
+          this.foo = 'valFoo';
+          this.setFoo = function (val) {
+            this.foo = val;
+          };
+        });
 
-        module.directive('mainWrap', function () {
+
+        module.directive('outerWrap', function () {
           return {
-            template: '<div>Outer template content. <br />Transcluded content:<div ng-transclude></div></div>',
+            template: '<div>Outer directive template content. <br />Transcluded content:<div ng-transclude></div></div>',
             restrict: 'EA',
             transclude: true,
-            controller: 'MainwrapCtrl',
-            controllerAs: 'mainwrapCtrl'
+            controller: 'OuterwrapCtrl',
+            controllerAs: 'outerwrapCtrl',
+            scope: true,
+            bindToController: true
+          };
+        });
+
+        module.directive('innerWrap', function () {
+          return {
+            template: '<div>Inner directive template content. <br />Transcluded content:<div ng-transclude></div></div>',
+            restrict: 'EA',
+            transclude: true,
+            controller: 'InnerwrapCtrl',
+            controllerAs: 'innerwrapCtrl',
+            scope: true,
+            bindToController: true
           };
         });
 

--- a/demos/transclude.html
+++ b/demos/transclude.html
@@ -47,8 +47,10 @@
         <column name="Name" width="300">
           <span>{{value}}</span>
         </column>
-        <column name="Gender" width="700">
-          <span>{{value}} (mainwrapCtrl.bar: {{ mainwrapCtrl.bar }}) {{ foo }}</span>
+        <column name="Gender" width="400">
+          <span>{{value}} <br>mainwrapCtrl.bar: <em>{{ mainwrapCtrl.bar }}</em> <br>$scope.foo: <em>{{ foo }}</em> <br>
+          <button ng-click="mainwrapCtrl.setBar('New Bar!')">Set "New Bar"</button>
+          </span>
         </column>
       </dtable>
     </main-wrap>
@@ -61,8 +63,11 @@
       System.import('dataTable').then(function(dt){
         var module = angular.module('app', [ dt.default.name ]);
 
-        module.controller('MainwrapCtrl', function($scope){
-          $scope.bar = 'valBar';
+        module.controller('MainwrapCtrl', function(){
+          this.bar = 'valBar';
+          this.setBar = function (val) {
+            this.bar = val;
+          };
         });
 
 
@@ -79,7 +84,7 @@
 
         module.controller('HomeController', function($scope, $http){
           $scope.options = {
-            rowHeight: 50,
+            rowHeight: 150,
             headerHeight: 50,
             footerHeight: false,
             scrollbarV: false

--- a/src/DataTableController.js
+++ b/src/DataTableController.js
@@ -12,7 +12,7 @@ export class DataTableController {
    * @param  {filter}
    */
   /*@ngInject*/
-  constructor($scope, $filter, $log, $transclude){
+  constructor($scope, $filter, $log){
     angular.extend(this, {
       $scope: $scope,
       $filter: $filter,
@@ -23,7 +23,7 @@ export class DataTableController {
 
     // set scope to the parent
     this.options.$outer = $scope.$parent;
-    
+
     $scope.$watch('dt.options.columns', (newVal, oldVal) => {
       if(newVal.length > oldVal.length){
         this.transposeColumnDefaults();
@@ -47,7 +47,7 @@ export class DataTableController {
 
   /**
    * Create columns from elements
-   * @param  {array} columnElms 
+   * @param  {array} columnElms
    */
   buildColumns(columnElms){
     if(columnElms && columnElms.length){
@@ -69,7 +69,7 @@ export class DataTableController {
             column[attrName] = val;
           }
 
-          // cuz putting className vs class on 
+          // cuz putting className vs class on
           // a element feels weird
           if(attrName === 'class'){
             column.className = attr.value;
@@ -158,12 +158,12 @@ export class DataTableController {
 
   /**
    * Adjusts the column widths to handle greed/etc.
-   * @param  {int} forceIdx 
+   * @param  {int} forceIdx
    */
   adjustColumns(forceIdx){
-    var width = this.options.internal.innerWidth - 
+    var width = this.options.internal.innerWidth -
       this.options.internal.scrollBarWidth;
-      
+
     if(this.options.columnMode === 'force'){
       ForceFillColumnWidths(this.options.columns, width, forceIdx);
     } else if(this.options.columnMode === 'flex') {
@@ -292,7 +292,7 @@ export class DataTableController {
 
   /**
    * Occurs when a row was selected
-   * @param  {object} rows   
+   * @param  {object} rows
    */
   onSelected(rows){
     this.onSelect({
@@ -302,7 +302,7 @@ export class DataTableController {
 
   /**
    * Occurs when a row was click but may not be selected.
-   * @param  {object} row   
+   * @param  {object} row
    */
   onRowClicked(row){
     this.onRowClick({

--- a/src/DataTableController.js
+++ b/src/DataTableController.js
@@ -21,8 +21,9 @@ export class DataTableController {
 
     this.defaults();
 
-    // set scope to the parent
-    this.options.$outer = $scope.$parent;
+    // set scope to the parent, unless it's $$transcluded, in which
+    // case it needs to be set to grandparent
+    this.options.$outer = $scope.$parent.$$transcluded ? $scope.$parent.$parent : $scope.$parent;
 
     $scope.$watch('dt.options.columns', (newVal, oldVal) => {
       if(newVal.length > oldVal.length){

--- a/src/DataTableDirective.js
+++ b/src/DataTableDirective.js
@@ -110,13 +110,6 @@ export function DataTableDirective($window, $timeout, throttle){
           angular.element($window).on('resize', throttle(() => {
             $timeout(resize);
           }));
-
-          $scope.$on('$destroy', () => {
-            // prevent memory leaks
-            angular.element($window).off('resize');
-            // remove column data from DOM
-            angular.element(document).find('body').removeData($attrs.dtId);
-          })
         }
       }
     }

--- a/src/DataTableDirective.js
+++ b/src/DataTableDirective.js
@@ -62,7 +62,7 @@ export function DataTableDirective($window, $timeout, throttle){
     compile: function(tElem, tAttrs){
       return {
         pre: function($scope, $elm, $attrs, ctrl){
-          $elm.columns = angular.element(document).find('body').data($attrs.dtId)
+          $elm.columns = angular.element(document).find('body').data($attrs.dtId);
           ctrl.buildColumns($elm.columns);
           ctrl.transposeColumnDefaults();
 
@@ -94,9 +94,16 @@ export function DataTableDirective($window, $timeout, throttle){
           resize();
           $timeout(resize);
           $elm.addClass('dt-loaded');
-          angular.element($window).bind('resize', throttle(() => {
+          angular.element($window).on('resize', throttle(() => {
             $timeout(resize);
           }));
+
+          $scope.$on('$destroy', () => {
+            // prevent memory leaks
+            angular.element($window).off('resize');
+            // remove column data from DOM
+            angular.element(document).find('body').removeData($attrs.dtId);
+          })
         }
       }
     }

--- a/src/DataTableDirective.js
+++ b/src/DataTableDirective.js
@@ -20,10 +20,18 @@ export function DataTableDirective($window, $timeout, throttle){
     },
     controllerAs: 'dt',
     template: function(element){
-      // Gets the column nodes to transposes to column objects
-      // http://stackoverflow.com/questions/30845397/angular-expressive-directive-design/30847609#30847609
-      element.columns = element[0].getElementsByTagName('column');
-      return `<div class="dt" ng-class="dt.tableCss()">
+      // workaround for problem storing data on an element that's then
+      // transcluded: https://github.com/Swimlane/angular-data-table/issues/43
+      var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+          var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
+          return v.toString(16);
+      });
+
+      var columns = element[0].getElementsByTagName('column');
+
+      angular.element(document).find('body').data(uuid, columns);
+
+      return `<div class="dt" ng-class="dt.tableCss()" dt-id="${ uuid }">
           <dt-header options="dt.options"
                      on-checkbox-change="dt.onHeaderCheckboxChange()"
                      columns="dt.columnsByPin"
@@ -54,6 +62,7 @@ export function DataTableDirective($window, $timeout, throttle){
     compile: function(tElem, tAttrs){
       return {
         pre: function($scope, $elm, $attrs, ctrl){
+          $elm.columns = angular.element(document).find('body').data($attrs.dtId)
           ctrl.buildColumns($elm.columns);
           ctrl.transposeColumnDefaults();
 

--- a/src/DataTableDirective.js
+++ b/src/DataTableDirective.js
@@ -27,8 +27,14 @@ export function DataTableDirective($window, $timeout, throttle){
           return v.toString(16);
       });
 
-      var columns = element[0].getElementsByTagName('column');
+      // store columns
+      var columnsEl = element[0].getElementsByTagName('column');
+      var columns = [];
 
+      // store only outerHTML rather than the whole DOM node
+      for (var i = 0; i < columnsEl.length; i++) {
+        columns.push( columnsEl[i].outerHTML );
+      };
       angular.element(document).find('body').data(uuid, columns);
 
       return `<div class="dt" ng-class="dt.tableCss()" dt-id="${ uuid }">
@@ -62,8 +68,15 @@ export function DataTableDirective($window, $timeout, throttle){
     compile: function(tElem, tAttrs){
       return {
         pre: function($scope, $elm, $attrs, ctrl){
-          $elm.columns = angular.element(document).find('body').data($attrs.dtId);
-          ctrl.buildColumns($elm.columns);
+          // get the column data stored on `body`
+          var columnSrc = angular.element(document).find('body').data($attrs.dtId);
+          var columnEl = [];
+          // create elements from the fetched template content
+          for (var i = 0; i < columnSrc.length; i++) {
+            columnEl.push( angular.element( columnSrc[i] )[0] );
+          };
+          // build the columns from created elements
+          ctrl.buildColumns(columnEl);
           ctrl.transposeColumnDefaults();
 
           ctrl.options.internal.scrollBarWidth = ScrollbarWidth();


### PR DESCRIPTION
@amcdnl this works for getting the columns through transclusion, and can be tested in `demos/transclude.html`.  Still working on getting access to the parent scope data, that seems not to work just yet.
