### PR TITLE
Fix translate function for safari

### DIFF
--- a/config.js
+++ b/config.js
@@ -15,9 +15,9 @@ System.config({
 
   map: {
     "angular": "npm:angular@1.4.0",
-    "babel": "npm:babel-core@5.8.21",
+    "babel": "npm:babel-core@5.8.22",
     "babel-runtime": "npm:babel-runtime@5.8.20",
-    "core-js": "npm:core-js@0.9.18",
+    "core-js": "npm:core-js@1.1.1",
     "github:jspm/nodelibs-process@0.1.1": {
       "process": "npm:process@0.10.1"
     },
@@ -27,7 +27,7 @@ System.config({
     "npm:babel-runtime@5.8.20": {
       "process": "github:jspm/nodelibs-process@0.1.1"
     },
-    "npm:core-js@0.9.18": {
+    "npm:core-js@1.1.1": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "process": "github:jspm/nodelibs-process@0.1.1",
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"

--- a/package.json
+++ b/package.json
@@ -66,9 +66,9 @@
       "angular": "npm:angular@^1.4.0"
     },
     "devDependencies": {
-      "babel": "npm:babel-core@^5.6.4",
+      "babel": "npm:babel-core@^5.8.22",
       "babel-runtime": "npm:babel-runtime@^5.6.4",
-      "core-js": "npm:core-js@^0.9.17"
+      "core-js": "npm:core-js@^1.1.1"
     }
   },
   "scripts": {

--- a/src/utils/translate.js
+++ b/src/utils/translate.js
@@ -1,5 +1,12 @@
 import { GetVendorPrefixedName } from './vendorPrefixes';
 
+// Transform property name to camelCase
+function camelize(str) {
+  return str.replace('-', '').replace(/-/g, ' ').replace(/(?:^\w|[A-Z]|\b\w)/g, function(letter, index) {
+    return index == 0 ? letter.toLowerCase() : letter.toUpperCase();
+  }).replace(/\s+/g, '');
+}
+
 // browser detection and prefixing tools
 var transform = GetVendorPrefixedName('transform'),
     backfaceVisibility = GetVendorPrefixedName('backfaceVisibility'),
@@ -14,7 +21,7 @@ export function TranslateXY(styles, x,y){
       styles[transform] = `translate3d(${x}px, ${y}px, 0)`;
       styles[backfaceVisibility] = 'hidden';
     } else {
-      styles[transform] = `translate(${x}px, ${y}px, 0)`;
+      styles[camelize(transform)] = `translate(${x}px, ${y}px)`;
     }
   } else {
     styles.top = y + 'px';

--- a/src/utils/translate.js
+++ b/src/utils/translate.js
@@ -1,11 +1,5 @@
 import { GetVendorPrefixedName } from './vendorPrefixes';
-
-// Transform property name to camelCase
-function camelize(str) {
-  return str.replace('-', '').replace(/-/g, ' ').replace(/(?:^\w|[A-Z]|\b\w)/g, function(letter, index) {
-    return index == 0 ? letter.toLowerCase() : letter.toUpperCase();
-  }).replace(/\s+/g, '');
-}
+import { CamelCase } from './utils';
 
 // browser detection and prefixing tools
 var transform = GetVendorPrefixedName('transform'),
@@ -21,7 +15,7 @@ export function TranslateXY(styles, x,y){
       styles[transform] = `translate3d(${x}px, ${y}px, 0)`;
       styles[backfaceVisibility] = 'hidden';
     } else {
-      styles[camelize(transform)] = `translate(${x}px, ${y}px)`;
+      styles[CamelCase(transform)] = `translate(${x}px, ${y}px)`;
     }
   } else {
     styles.top = y + 'px';

--- a/src/utils/vendorPrefixes.js
+++ b/src/utils/vendorPrefixes.js
@@ -19,7 +19,7 @@ var prefix = (function () {
   var styles = window.getComputedStyle(document.documentElement, ''),
     pre = (Array.prototype.slice
       .call(styles)
-      .join('') 
+      .join('')
       .match(/-(moz|webkit|ms)-/) || (styles.OLink === '' && ['', 'o'])
     )[1],
     dom = ('WebKit|Moz|MS|O').match(new RegExp('(' + pre + ')', 'i'))[1];


### PR DESCRIPTION
Replaces -webkit-transform with webkitTransform when on safari

Upgrades babel and corejs to versions compatible with jspm 0.16.1
