### PR TITLE
Delete dom elements cache after build

### DIFF
--- a/src/components/DataTableService.js
+++ b/src/components/DataTableService.js
@@ -67,5 +67,6 @@ export let DataTableService = {
         this.columns[id].push(column);
       });
     });
+    this.dTables = {};
   }
 };


### PR DESCRIPTION
Continuation of #72 
This will clear the raw elements after being built.  

Originally I tried to replace each item with the built version but had issues with binding.  I tried again but still cannot get it.
