### PR TITLE
Add support for sortType of "simple".

### DIFF
--- a/demos/sort.html
+++ b/demos/sort.html
@@ -59,7 +59,7 @@
             headerHeight: 50,
             footerHeight: false,
             scrollbarV: false,
-            sortType: 'default', // other option: 'simple'
+            sortType: 'multiple', // other option: 'single'
             columns: [
               { name: "Name", prop: "name", width: 300, sort: 'desc' },
               { name: "Gender", prop: "gender" },

--- a/demos/sort.html
+++ b/demos/sort.html
@@ -59,6 +59,7 @@
             headerHeight: 50,
             footerHeight: false,
             scrollbarV: false,
+            sortType: 'default', // other option: 'simple'
             columns: [
               { name: "Name", prop: "name", width: 300, sort: 'desc' },
               { name: "Gender", prop: "gender" },

--- a/src/components/header/HeaderCellController.js
+++ b/src/components/header/HeaderCellController.js
@@ -36,7 +36,7 @@ export class HeaderCellController{
     var sortType = this.sortType;
 
     function getNextSort(currentSort) {
-      if (sortType === 'simple') {
+      if (sortType === 'single') {
         if(currentSort === 'asc'){
           return 'desc';
         } else {

--- a/src/components/header/HeaderCellController.js
+++ b/src/components/header/HeaderCellController.js
@@ -33,15 +33,27 @@ export class HeaderCellController{
    * Toggles the sorting on the column
    */
   onSorted(){
-    if(this.column.sortable){
-      if(!this.column.sort){
-        this.column.sort = 'asc';
-      } else if(this.column.sort === 'asc'){
-        this.column.sort = 'desc';
-      } else if(this.column.sort === 'desc'){
-        this.column.sort = undefined;
+    var sortType = this.sortType;
+    function getNextSort(currentSort) {
+      if (sortType === 'simple') {
+        if(currentSort === 'asc'){
+          return 'desc';
+        } else {
+          return 'asc';
+        }
+      } else {
+        if(!currentSort){
+          return 'asc';
+        } else if(currentSort === 'asc'){
+          return 'desc';
+        } else if(currentSort === 'desc'){
+          return undefined;
+        }
       }
+    }
 
+    if(this.column.sortable){
+      this.column.sort = getNextSort(this.column.sort);
       this.onSort({
         column: this.column
       });

--- a/src/components/header/HeaderCellController.js
+++ b/src/components/header/HeaderCellController.js
@@ -1,3 +1,5 @@
+import { NextSortDirection } from 'utils/utils';
+
 export class HeaderCellController{
 
   /**
@@ -33,28 +35,9 @@ export class HeaderCellController{
    * Toggles the sorting on the column
    */
   onSorted(){
-    var sortType = this.sortType;
-
-    function getNextSort(currentSort) {
-      if (sortType === 'single') {
-        if(currentSort === 'asc'){
-          return 'desc';
-        } else {
-          return 'asc';
-        }
-      } else {
-        if(!currentSort){
-          return 'asc';
-        } else if(currentSort === 'asc'){
-          return 'desc';
-        } else if(currentSort === 'desc'){
-          return undefined;
-        }
-      }
-    }
-
     if(this.column.sortable){
-      this.column.sort = getNextSort(this.column.sort);
+      this.column.sort = NextSortDirection(this.sortType, this.column.sort);
+
       this.onSort({
         column: this.column
       });

--- a/src/components/header/HeaderCellController.js
+++ b/src/components/header/HeaderCellController.js
@@ -34,6 +34,7 @@ export class HeaderCellController{
    */
   onSorted(){
     var sortType = this.sortType;
+
     function getNextSort(currentSort) {
       if (sortType === 'simple') {
         if(currentSort === 'asc'){

--- a/src/components/header/HeaderCellDirective.js
+++ b/src/components/header/HeaderCellDirective.js
@@ -11,6 +11,7 @@ export function HeaderCellDirective($compile){
       column: '=',
       onCheckboxChange: '&',
       onSort: '&',
+      sortType: '=',
       onResize: '&',
       selected: '='
     },

--- a/src/components/header/HeaderController.js
+++ b/src/components/header/HeaderController.js
@@ -31,9 +31,9 @@ export class HeaderController {
    * @param  {object} column
    */
   onSorted(sortedColumn){
-    // if sortType is 'simple' then we don't allow more than one column to be
-    // sorted at once
     if (this.options.sortType === 'simple') {
+      // if sort type is simple, then only one column can be sorted at once,
+      // so we set the sort to undefined for the other columns
       function unsortColumn(column) {
         if (column !== sortedColumn) {
           column.sort = undefined;

--- a/src/components/header/HeaderController.js
+++ b/src/components/header/HeaderController.js
@@ -30,9 +30,23 @@ export class HeaderController {
    * @param  {object} scope
    * @param  {object} column
    */
-  onSorted(column){
+  onSorted(sortedColumn){
+    // if sortType is 'simple' then we don't allow more than one column to be
+    // sorted at once
+    if (this.options.sortType === 'simple') {
+      function unsortColumn(column) {
+        if (column !== sortedColumn) {
+          column.sort = undefined;
+        }
+      }
+
+      this.columns.left.forEach(unsortColumn);
+      this.columns.center.forEach(unsortColumn);
+      this.columns.right.forEach(unsortColumn);
+    }
+
     this.onSort({
-      column: column
+      column: sortedColumn
     });
   }
 

--- a/src/components/header/HeaderController.js
+++ b/src/components/header/HeaderController.js
@@ -31,8 +31,8 @@ export class HeaderController {
    * @param  {object} column
    */
   onSorted(sortedColumn){
-    if (this.options.sortType === 'simple') {
-      // if sort type is simple, then only one column can be sorted at once,
+    if (this.options.sortType === 'single') {
+      // if sort type is single, then only one column can be sorted at once,
       // so we set the sort to undefined for the other columns
       function unsortColumn(column) {
         if (column !== sortedColumn) {

--- a/src/components/header/HeaderDirective.js
+++ b/src/components/header/HeaderDirective.js
@@ -17,6 +17,7 @@ export function HeaderDirective($timeout){
     },
     template: `
       <div class="dt-header" ng-style="header.styles()">
+
         <div class="dt-header-inner" ng-style="header.innerStyles()">
           <div class="dt-row-left"
                ng-style="header.stylesByGroup('left')"
@@ -26,6 +27,7 @@ export function HeaderDirective($timeout){
             <dt-header-cell ng-repeat="column in header.columns['left'] track by column.$id"
                             on-checkbox-change="header.onCheckboxChanged()"
                             on-sort="header.onSorted(column)"
+                            sort-type="header.options.sortType"
                             on-resize="header.onResized(column, width)"
                             selected="header.isSelected()"
                             column="column">
@@ -38,6 +40,7 @@ export function HeaderDirective($timeout){
             <dt-header-cell ng-repeat="column in header.columns['center'] track by column.$id"
                             on-checkbox-change="header.onCheckboxChanged()"
                             on-sort="header.onSorted(column)"
+                            sort-type="header.options.sortType"
                             selected="header.isSelected()"
                             on-resize="header.onResized(column, width)"
                             column="column">
@@ -51,6 +54,7 @@ export function HeaderDirective($timeout){
             <dt-header-cell ng-repeat="column in header.columns['right'] track by column.$id"
                             on-checkbox-change="header.onCheckboxChanged()"
                             on-sort="header.onSorted(column)"
+                            sort-type="header.options.sortType"
                             selected="header.isSelected()"
                             on-resize="header.onResized(column, width)"
                             column="column">

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -129,3 +129,21 @@ export function ScrollbarWidth() {
 
   return widthNoScroll - widthWithScroll;
 };
+
+export function NextSortDirection(sortType, currentSort) {
+  if (sortType === 'single') {
+    if(currentSort === 'asc'){
+      return 'desc';
+    } else {
+      return 'asc';
+    }
+  } else {
+    if(!currentSort){
+      return 'asc';
+    } else if(currentSort === 'asc'){
+      return 'desc';
+    } else if(currentSort === 'desc'){
+      return undefined;
+    }
+  }
+};


### PR DESCRIPTION
The sortable columns in the angular-data-table directive normally toggle between three states: "asc", "desc" and undefined.

This PR adds the option "sortType" (possible values `'default'` and `'simple'`, defaults to `'default'`). If simple is set then the columns will only toggle between ascending an descending, and if you sort a new column it stops trying to sort by all other columns.
