### PR TITLE
use github angular dependencies 

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {},
   "jspm": {
     "dependencies": {
-      "angular": "npm:angular@^1.4.0"
+      "angular": "github:angular/bower-angular@^1.4.8"
     },
     "devDependencies": {
       "babel": "npm:babel-core@^5.8.22",


### PR DESCRIPTION
please use github:angular/bower-angular as dependencies

as http://kasperlewau.github.io/registry/#/ , angular in jspm official repo is github:angular/bower-angular, not npm:angular. if a user install angular using

``` bash
jspm install angular
```

then when installing angular-data-table, there will be 2 versions of angular.

and...npm version angular has many nodelibs dependencies, they are not needed. github version don't.
