### PR TITLE
Render HTML in cells

### DIFF
--- a/src/components/body/CellDirective.js
+++ b/src/components/body/CellDirective.js
@@ -62,7 +62,7 @@ export function CellDirective($rootScope, $compile, $log, $timeout){
               var elm = angular.element(ctrl.column.cellRenderer(cellScope, content));
               content.append($compile(elm)(cellScope));
             } else {
-              content[0].textContent = ctrl.getValue();
+              content[0].innerHTML = ctrl.getValue();
             }
           }, true);
         }


### PR DESCRIPTION
When a cell value contains HTML code, it currently inserts it as text. This pull request updates the data table to render all HTML in the cell content.
