### PR TITLE
Display data changes in UI

### DIFF
--- a/demos/updating.html
+++ b/demos/updating.html
@@ -35,6 +35,10 @@
         margin:50px auto;
       }
 
+      .changed {
+        background:#FFDC00;
+      }
+
     </style>
     <link href="../dist/dataTable.css" media="all" rel="stylesheet" />
     <link href="../dist/themes/material.css" media="all" rel="stylesheet" />
@@ -55,7 +59,7 @@
       System.import('dataTable').then(function(dt){
         var module = angular.module('app', [ dt.default.name ]);
 
-        module.controller('HomeController', function($scope, $http){
+        module.controller('HomeController', function($scope, $http, $timeout){
           $scope.options = {
             rowHeight: 50,
             headerHeight: 50,
@@ -95,9 +99,16 @@
           });
 
           $scope.change = function(){
-            for(var i=0;i<$scope.data.length;i++){
+            var randPos = Math.floor(Math.random() * $scope.data.length);
+            for(var i = 0; i < randPos; i++){
+              $scope.data[i].changed = true;
               $scope.data[i].imgSrc = 'http://cdn.javabeat.net/wp-content/uploads/2014/05/angularjs.png';
-            }   
+            }
+            $timeout(function() {
+              for(var i = 0; i < $scope.data.length; i++){
+                $scope.data[i].changed = false;
+              }
+            }, 2000)
           }
 
         });

--- a/src/components/body/BodyController.js
+++ b/src/components/body/BodyController.js
@@ -387,6 +387,7 @@ export class BodyController{
    */
   rowClasses(row){
     var styles = {
+      'changed': row.changed,
       'selected': this.isSelected(row),
       'dt-row-even': row && row.$$index%2 === 0,
       'dt-row-odd': row && row.$$index%2 !== 0


### PR DESCRIPTION
This changeset allows rows to briefly change row color based on data changing. This solution is what I'm thinking of <a href="https://github.com/Swimlane/angular-data-table/issues/125"> based on this feature request I had here </a>, but please let me know what solution makes the most sense. I updated the <code>updating</code> example with the changes.

As an aside, I believe this feature would get broadly used as I'd think there a number of applications that use angular-data-table and are consistently polling for updated numbers (it's at least true for my use case). 
