### PR TITLE
Fix multi-column sorting

### DIFF
--- a/demos/sort.html
+++ b/demos/sort.html
@@ -43,7 +43,7 @@
   <body ng-app="app" ng-controller="HomeController">
 
 
-    <dtable options="options" rows="data" class="material"></dtable>
+    <dtable options="options" rows="data" class="material" on-sort="onColumnSort"></dtable>
 
     <script src="../jspm_packages/system.js"></script>
     <script src="../config.js"></script>
@@ -54,16 +54,40 @@
         var module = angular.module('app', [ dt.default.name ]);
 
         module.controller('HomeController', function($scope, $http){
+
+          $scope.onColumnSort = (columns) => {
+            console.log('Sorting:')
+            columns.forEach((c) => {
+              console.log(`${c.sortPriority}. ${c.name} - ${c.sort}`, c)
+            })
+          }
+
           $scope.options = {
             rowHeight: 50,
             headerHeight: 50,
             footerHeight: false,
             scrollbarV: false,
-            sortType: 'multiple', // other option: 'single'
-            columns: [
-              { name: "Name", prop: "name", width: 300, sort: 'desc' },
-              { name: "Gender", prop: "gender" },
-              { name: "Company", prop: "company" }
+            sortType: 'multiple', // available options: ['single', 'multiple']
+            // onSort: $scope.onColumnSort,
+            columns: [{
+                name: "Name",
+                prop: "name",
+                width: 300,
+                sort: 'desc',
+                sortPriority: 2
+              },
+              {
+                name: "Gender",
+                prop: "gender",
+                sort: 'asc',
+                sortPriority: 1
+              },
+              {
+                name: "Company",
+                prop: "company",
+                sort: 'asc',
+                sortPriority: 3
+              }
             ]
           };
 

--- a/src/components/DataTableController.js
+++ b/src/components/DataTableController.js
@@ -136,12 +136,38 @@ export class DataTableController {
   onSorted(){
     if(!this.rows) return;
 
-    var sorts = this.options.columns.filter((c) => {
-      return c.sort;
-    });
+    // return all sorted column, in the same order in which they were sorted
+    var sorts = this.options.columns
+      .filter((c) => {
+        return c.sort;
+      })
+      .sort((a, b) => {
+        // sort the columns with lower sortPriority order first
+        if (a.sortPriority && b.sortPriority){
+          if (a.sortPriority > b.sortPriority) return 1;
+          if (a.sortPriority < b.sortPriority) return -1;
+        } else if (a.sortPriority){
+          return -1;
+        } else if (b.sortPriority){
+          return 1;
+        }
+
+        return 0;
+      })
+      .map((c, i) => {
+        // update sortPriority
+        c.sortPriority = i + 1;
+        return c;
+      });
 
     if(sorts.length){
-        this.onSort({ sorts: sorts });
+      if (this.onSort()){
+        this.onSort()(sorts);
+      }
+
+      if (this.options.onSort){
+        this.options.onSort(sorts);
+      }
 
       var clientSorts = [];
       for(var i=0, len=sorts.length; i < len; i++) {
@@ -259,7 +285,7 @@ export class DataTableController {
       row: row
     });
   }
-  
+
   /**
    * Occurs when a row was double click but may not be selected.
    * @param  {object} row

--- a/src/components/header/HeaderCellController.js
+++ b/src/components/header/HeaderCellController.js
@@ -1,7 +1,6 @@
 import { NextSortDirection } from '../../utils/utils';
 
 export class HeaderCellController{
-
   /**
    * Calculates the styles for the header cell directive
    * @return {styles}
@@ -37,6 +36,10 @@ export class HeaderCellController{
   onSorted(){
     if(this.column.sortable){
       this.column.sort = NextSortDirection(this.sortType, this.column.sort);
+
+      if (this.column.sort === undefined){
+        this.column.sortPriority = undefined;
+      }
 
       this.onSort({
         column: this.column

--- a/src/components/header/HeaderCellDirective.js
+++ b/src/components/header/HeaderCellDirective.js
@@ -46,7 +46,7 @@ export function HeaderCellDirective($compile){
 
           if(ctrl.column.headerTemplate || ctrl.column.headerRenderer){
             cellScope = ctrl.options.$outer.$new(false);
-            
+
             // copy some props
             cellScope.$header = ctrl.column.name;
             cellScope.$index = $scope.$index;

--- a/src/components/header/HeaderController.js
+++ b/src/components/header/HeaderController.js
@@ -81,9 +81,9 @@ export class HeaderController {
 
   /**
    * Occurs when a header cell directive triggered a resize
-   * @param  {object} scope  
-   * @param  {object} column 
-   * @param  {int} width  
+   * @param  {object} scope
+   * @param  {object} column
+   * @param  {int} width
    */
   onResized(column, width){
     this.onResize({


### PR DESCRIPTION
- Fixes the multi-column sorting - columns that have been sorted earlier will always be sorted first.
- Fixes the on-sort callback on the dtable directive and adds an onSort callback to the options object
- Updates the sort demo page
- Fixes #128 
