### PR TITLE
Respect minimum column widths

### DIFF
--- a/src/components/header/ResizableDirective.js
+++ b/src/components/header/ResizableDirective.js
@@ -38,7 +38,7 @@ export function ResizableDirective($document, $timeout){
       function mousemove(event) {
         event = event.originalEvent || event;
         
-        var width = parent[0].scrollWidth,
+        var width = parent[0].clientWidth,
             movementX = event.movementX || event.mozMovementX || (event.screenX - prevScreenX),
             newWidth = width + (movementX || 0);
 
@@ -54,7 +54,7 @@ export function ResizableDirective($document, $timeout){
       function mouseup() {
         if($scope.onResize){
           $timeout(() => {
-            $scope.onResize({ width: parent[0].scrollWidth });
+            $scope.onResize({ width: parent[0].clientWidth });
           });
         }
 


### PR DESCRIPTION
This changeset will prioritize the minimum column widths set over the content width of a column header cell, [as discussed in this issue](https://github.com/Swimlane/angular-data-table/issues/144).
