### PR TITLE
[BUG] Calculate the size depending on the size of the enclosing element

### DIFF
--- a/src/components/DataTableDirective.js
+++ b/src/components/DataTableDirective.js
@@ -79,7 +79,7 @@ export function DataTableDirective($window, $timeout, $parse){
            * Invoked on init of control or when the window is resized;
            */
           function resize() {
-            var rect = $elm[0].getBoundingClientRect();
+            var rect = $elm[0].parentNode.getBoundingClientRect();
 
             ctrl.options.internal.innerWidth = Math.floor(rect.width);
 


### PR DESCRIPTION
Weird things happen during resize as the div is not constrained in any way. Wrapping the datatable inside an other size-constrained parent element works with this change.

Signed-off-by: Jaap de Haan jaap.dehaan@color-of-code.de
