### PR TITLE
Stop memory leaks

### DIFF
--- a/src/components/DataTableDirective.js
+++ b/src/components/DataTableDirective.js
@@ -102,10 +102,9 @@ export function DataTableDirective($window, $timeout, $parse){
             ctrl.adjustColumns();
           };
 
-          $window.addEventListener('resize',
-            throttle(() => {
-              $timeout(resize);
-            }));
+          angular.element($window).on('resize', throttle(() => {
+            $timeout(resize);
+          }));
 
           // When an item is hidden for example
           // in a tab with display none, the height


### PR DESCRIPTION
Replaces a call to `addEventListener` with `angular.element(...).on()` so that the callback will be properly removed once the data table is destroyed.